### PR TITLE
refactor: ViewModelProviders --> ViewModelProvider

### DIFF
--- a/app/src/main/java/com/google/firebase/example/fireeats/MainActivity.java
+++ b/app/src/main/java/com/google/firebase/example/fireeats/MainActivity.java
@@ -28,7 +28,7 @@ import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
-import androidx.lifecycle.ViewModelProviders;
+import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -86,7 +86,7 @@ public class MainActivity extends AppCompatActivity implements
         findViewById(R.id.button_clear_filter).setOnClickListener(this);
 
         // View model
-        mViewModel = ViewModelProviders.of(this).get(MainActivityViewModel.class);
+        mViewModel = new ViewModelProvider(this).get(MainActivityViewModel.class);
 
         // Enable Firestore logging
         FirebaseFirestore.setLoggingEnabled(true);


### PR DESCRIPTION
Starting in version 2.2.0 of the lifecycle library, the [ViewModelProviders](https://developer.android.com/reference/kotlin/androidx/lifecycle/ViewModelProviders) class has been deprecated. We should now use the [ViewModelProvider](https://developer.android.com/reference/androidx/lifecycle/ViewModelProvider) constructor instead.