### PR TITLE
Dependencies updates

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,12 +4,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion '30.0.0'
+    compileSdkVersion 32
     defaultConfig {
         applicationId 'com.google.firebase.example.fireeats'
-        minSdkVersion 16
-        targetSdkVersion 30
+        minSdkVersion 19
+        targetSdkVersion 32
         versionCode 1
         versionName '1.0'
 
@@ -26,7 +25,7 @@ android {
 
 dependencies {
     // Firestore
-    implementation 'com.google.firebase:firebase-firestore:23.0.3'
+    implementation 'com.google.firebase:firebase-firestore:24.0.1'
 
     // Other Firebase/Play services deps
     implementation 'com.google.firebase:firebase-auth:21.0.1'
@@ -36,18 +35,18 @@ dependencies {
     implementation 'com.firebaseui:firebase-ui-auth:8.0.0'
 
     // Support Libs
-    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'androidx.vectordrawable:vectordrawable-animated:1.1.0'
     implementation 'androidx.cardview:cardview:1.0.0'
-    implementation 'androidx.browser:browser:1.0.0'
-    implementation 'com.google.android.material:material:1.4.0'
+    implementation 'androidx.browser:browser:1.3.0'
+    implementation 'com.google.android.material:material:1.5.0'
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
 
     // Android architecture components
-    implementation 'androidx.lifecycle:lifecycle-runtime:2.3.1'
+    implementation 'androidx.lifecycle:lifecycle-runtime:2.4.1'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
-    annotationProcessor 'androidx.lifecycle:lifecycle-compiler:2.3.1'
+    annotationProcessor 'androidx.lifecycle:lifecycle-compiler:2.4.1'
 
     // Third-party libraries
     implementation 'me.zhanghai.android.materialratingbar:library:1.4.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,8 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,11 +4,11 @@ buildscript {
     
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.0'
-        classpath 'com.google.gms:google-services:4.3.8'
+        classpath 'com.google.gms:google-services:4.3.10'
     }
 }
 
@@ -19,7 +19,7 @@ plugins {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         mavenLocal()
     }
 


### PR DESCRIPTION
Firestore version and a few other dependencies needed update. Due to this update I needed to raise the minimum supported API from 16 to 19 and add `android:exported` to the `AndroidManifest`. Also replaced `jcenter()` by `mavenCentral()` because the old one is now deprecated.