### PR TITLE
apply `versions` plugin at module level

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("org.jetbrains.kotlin.android") version "1.8.20" apply false
     id("com.google.gms.google-services") version "4.3.15" apply false
     id("androidx.navigation.safeargs") version "2.5.3" apply false
-    id("com.github.ben-manes.versions") version "0.41.0" apply false
+    id("com.github.ben-manes.versions") version "0.41.0" apply true
 }
 
 allprojects {


### PR DESCRIPTION
Turns out this plugin needs to be applied at the module level in order to register the `dependencyUpdates` task, otherwise dpebot fails with:

```
Task 'dependencyUpdates' not found in root project 'repo-to-update' and its subprojects.
```